### PR TITLE
refactor: hoist nested React components to module level

### DIFF
--- a/apps/web/components/apps/installation/EventTypeConferencingAppSettings.tsx
+++ b/apps/web/components/apps/installation/EventTypeConferencingAppSettings.tsx
@@ -68,17 +68,19 @@ const LocationsWrapper = ({
   );
 };
 
-const EventTypeConferencingAppSettings = ({ eventType, slug }: { eventType: TEventType; slug: string }) => {
-  const locationsQuery = trpc.viewer.apps.locationOptions.useQuery({});
-  const { t } = useLocale();
-
-  const SkeletonLoader = () => {
+const SkeletonLoader = () => {
     return (
       <SkeletonContainer>
         <SkeletonText className="my-2 h-8 w-full" />
       </SkeletonContainer>
     );
   };
+
+const EventTypeConferencingAppSettings = ({ eventType, slug }: { eventType: TEventType; slug: string }) => {
+  const locationsQuery = trpc.viewer.apps.locationOptions.useQuery({});
+  const { t } = useLocale();
+
+  
 
   return (
     <QueryCell

--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -136,6 +136,14 @@ const ConditionalLink = ({
   );
 };
 
+const RequestSentMessage = () => {
+    return (
+      <Badge startIcon="send" size="md" variant="gray" data-testid="request_reschedule_sent">
+        {t("reschedule_request_sent")}
+      </Badge>
+    );
+  };
+
 function BookingListItem(booking: BookingItemProps) {
   const parsedBooking = buildParsedBooking(booking);
   const itemRef = useRef<HTMLDivElement>(null);
@@ -239,13 +247,7 @@ function BookingListItem(booking: BookingItemProps) {
     t,
   } as BookingActionContext;
 
-  const RequestSentMessage = () => {
-    return (
-      <Badge startIcon="send" size="md" variant="gray" data-testid="request_reschedule_sent">
-        {t("reschedule_request_sent")}
-      </Badge>
-    );
-  };
+  
 
   const bookingYear = dayjs(booking.startTime).year();
   const currentYear = dayjs().year();

--- a/apps/web/modules/settings/platform/managed-users/managed-users-view.tsx
+++ b/apps/web/modules/settings/platform/managed-users/managed-users-view.tsx
@@ -14,22 +14,7 @@ import Shell from "~/shell/Shell";
 
 type OAuthClientOption = { label: string; value: string };
 
-const ManagedUsersView = () => {
-  const { t } = useLocale();
-  const { data: OAuthClientsQueryData, error, isLoading: isOAuthClientLoading } = useOAuthClients();
-
-  const oAuthClientOptions: OAuthClientOption[] = useMemo(
-    () =>
-      OAuthClientsQueryData.map((client) => ({
-        label: client.name,
-        value: client.id,
-      })),
-    [OAuthClientsQueryData]
-  );
-
-  const [oAuthClient, setOAuthClient] = useState<OAuthClientOption | null>(oAuthClientOptions[0] || null);
-
-  const ManagedUsersSkeletonLoader = () => {
+const ManagedUsersSkeletonLoader = () => {
     return (
       <div className="flex">
         <div className="w-1/4 p-4" />
@@ -56,6 +41,23 @@ const ManagedUsersView = () => {
       </div>
     );
   };
+
+const ManagedUsersView = () => {
+  const { t } = useLocale();
+  const { data: OAuthClientsQueryData, error, isLoading: isOAuthClientLoading } = useOAuthClients();
+
+  const oAuthClientOptions: OAuthClientOption[] = useMemo(
+    () =>
+      OAuthClientsQueryData.map((client) => ({
+        label: client.name,
+        value: client.id,
+      })),
+    [OAuthClientsQueryData]
+  );
+
+  const [oAuthClient, setOAuthClient] = useState<OAuthClientOption | null>(oAuthClientOptions[0] || null);
+
+  
 
   if (isOAuthClientLoading) {
     return <ManagedUsersSkeletonLoader />;


### PR DESCRIPTION
## Summary
This PR hoists nested React component definitions to module level to prevent unnecessary re-renders and improve performance.

## Changes
- **EventTypeConferencingAppSettings.tsx**: Hoisted `EventTypeConferencingAppSettings` and `SkeletonLoader` components
- **BookingListItem.tsx**: Hoisted `RequestSentMessage` component
- **managed-users-view.tsx**: Hoisted `ManagedUsersSkeletonLoader` and `ManagedUsersView` components

## Why
When component definitions are nested inside other components, React recreates them on every render, which can lead to:
- Unnecessary re-renders of child components
- Loss of component state
- Performance degradation

By hoisting these components to module level, they are defined once and reused across renders.

## Testing
- [ ] Type check passes: `yarn type-check:ci --force`
- [ ] Lint passes: `yarn biome check --write .`

Co-Authored-By: Oz <oz-agent@warp.dev>